### PR TITLE
Contador de detalhes não zera ao iniciar um novo lote

### DIFF
--- a/libs/jsonsToCnab.js
+++ b/libs/jsonsToCnab.js
@@ -44,6 +44,7 @@ class JsonsToCnab {
         this.lots[this.lots.length-1][1] = []
         this.lots[this.lots.length-1][2] = []
         this.lotNumber += 1
+        this.detailNumberInCurrentLot = 0;
     }
 
     counterLots() {


### PR DESCRIPTION
De acordo com a documentação do SISPAG do Itaú por exemplo, na NOTA 9:

> Registro Detalhe - É o número sequencial de um pagamento dentro do lote.

Dado que utilizamos o método counterDetailsInCurrentLot() do jsonsToCnab.js para retornar a quantidade de registros no lote atual.
O ponto é, quando temos mais de um lote, ele n zera essa contagem, acumulando assim para o lote seguinte.


A correção que fiz, propoe justamente isso.